### PR TITLE
Optional saving

### DIFF
--- a/Example/Tests/KBStorageManagerTests.swift
+++ b/Example/Tests/KBStorageManagerTests.swift
@@ -55,34 +55,6 @@ class KBStorageManagerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
-    func testOptionalMemoryWrite() {
-        let someData = "text".data(using: .utf8)!
-        let asset = KBDataAsset(identifier: "testOptionalMemoryWrite".hashValue, data: someData)
-
-        let expectWrite = expectation(description: "testOptionalMemoryWrite")
-        storageManager
-            .store(asset, writeOption: [.memory, .optional])
-            .subscribe(onCompleted: {
-                expectWrite.fulfill()
-            }) { (error) in
-                XCTFail("Could not write to memory")
-            }
-            .disposed(by: disposeBag)
-
-        let expectSkip = expectation(description: "testOptionalMemorySkip")
-        storageManager
-            .store(asset, writeOption: [.memory, .optional])
-            .subscribe(onCompleted: {
-                XCTFail("Should not have writted to memory")
-            }) { (error) in
-                XCTAssertEqual(error as? KBStorageError, KBStorageError.optionalSkip)
-                expectSkip.fulfill()
-            }
-            .disposed(by: disposeBag)
-
-        waitForExpectations(timeout: 0.5, handler: nil)
-    }
-
     // Ability to write to disk
     func testDiskWrite() {
         let someData = "text".data(using: .utf8)!
@@ -95,34 +67,6 @@ class KBStorageManagerTests: XCTestCase {
                 expect.fulfill()
             }) { (error) in
                 XCTFail()
-            }
-            .disposed(by: disposeBag)
-
-        waitForExpectations(timeout: 0.5, handler: nil)
-    }
-
-    func testOptionalDiskWrite() {
-        let someData = "text".data(using: .utf8)!
-        let asset = KBDataAsset(identifier: "testOptionalDiskWrite".hashValue, data: someData)
-
-        let expectWrite = expectation(description: "testOptionalDiskWrite")
-        storageManager
-            .store(asset, writeOption: [.disk, .optional])
-            .subscribe(onCompleted: {
-                expectWrite.fulfill()
-            }) { (error) in
-                XCTFail("Could not write to disk")
-            }
-            .disposed(by: disposeBag)
-
-        let expectSkip = expectation(description: "testOptionalDiskSkip")
-        storageManager
-            .store(asset, writeOption: [.disk, .optional])
-            .subscribe(onCompleted: {
-                XCTFail("Should not have writted to disk")
-            }) { (error) in
-                XCTAssertEqual(error as? KBStorageError, KBStorageError.optionalSkip)
-                expectSkip.fulfill()
             }
             .disposed(by: disposeBag)
 
@@ -193,6 +137,7 @@ class KBStorageManagerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
+    // Clearing data
     func testClearMemory() {
         let someData = "text".data(using: .utf8)!
         let identifier = "testClearMemory".hashValue
@@ -293,6 +238,7 @@ class KBStorageManagerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
+    // Asset Expiry
     func testAssetExpiry() {
         let someData = "text".data(using: .utf8)!
         let identifier = "testAssetExpiry".hashValue
@@ -336,5 +282,149 @@ class KBStorageManagerTests: XCTestCase {
             .disposed(by: disposeBag)
 
         waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    // Optionality
+    func testOptionalMemoryWrite() {
+        let someData = "text".data(using: .utf8)!
+        let asset = KBDataAsset(identifier: "testOptionalMemoryWrite".hashValue, data: someData)
+
+        let expectWrite = expectation(description: "testOptionalMemoryWrite")
+        storageManager
+            .store(asset, writeOption: [.memory, .optional])
+            .subscribe(onCompleted: {
+                expectWrite.fulfill()
+            }) { (error) in
+                XCTFail("Could not write to memory")
+            }
+            .disposed(by: disposeBag)
+
+        let expectSkip = expectation(description: "testOptionalMemorySkip")
+        storageManager
+            .store(asset, writeOption: [.memory, .optional])
+            .subscribe(onCompleted: {
+                XCTFail("Should not have written to memory")
+            }) { (error) in
+                XCTAssertEqual(error as? KBStorageError, KBStorageError.optionalSkip)
+                expectSkip.fulfill()
+            }
+            .disposed(by: disposeBag)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testOptionalDiskWrite() {
+        let someData = "text".data(using: .utf8)!
+        let asset = KBDataAsset(identifier: "testOptionalDiskWrite".hashValue, data: someData)
+
+        let expectWrite = expectation(description: "testOptionalDiskWrite")
+        storageManager
+            .store(asset, writeOption: [.disk, .optional])
+            .subscribe(onCompleted: {
+                expectWrite.fulfill()
+            }) { (error) in
+                XCTFail("Could not write to disk")
+            }
+            .disposed(by: disposeBag)
+
+        let expectSkip = expectation(description: "testOptionalDiskSkip")
+        storageManager
+            .store(asset, writeOption: [.disk, .optional])
+            .subscribe(onCompleted: {
+                XCTFail("Should not have written to disk")
+            }) { (error) in
+                XCTAssertEqual(error as? KBStorageError, KBStorageError.optionalSkip)
+                expectSkip.fulfill()
+            }
+            .disposed(by: disposeBag)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testSecondayNonOptionalMemoryWrite() {
+        // Writing to memory once, and then trying again optionally should return .optionalSkip
+        // But writing to memory the second time non-optionally should overwrite existing record and return successful
+        let someData = "text".data(using: .utf8)!
+        let asset = KBDataAsset(identifier: "testSecondayNonOptionalWrite".hashValue, data: someData)
+
+        let expectWrite = expectation(description: "testSecondayNonOptionalWrite")
+        storageManager
+            .store(asset, writeOption: [.memory, .optional])
+            .subscribe(onCompleted: {
+                expectWrite.fulfill()
+            }) { (error) in
+                XCTFail("Could not write to memory")
+            }
+            .disposed(by: disposeBag)
+
+        let expectSecondWrite = expectation(description: "testSecondayNonOptionalSecondWrite")
+        storageManager
+            .store(asset, writeOption: [.memory])
+            .subscribe(onCompleted: {
+                expectSecondWrite.fulfill()
+            }) { (error) in
+                XCTFail("Should have written to memory")
+            }
+            .disposed(by: disposeBag)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testSecondayNonOptionalDiskWrite() {
+        // Writing to disk once, and then trying again optionally should return .optionalSkip
+        // But writing to disk the second time non-optionally should overwrite existing record and return successful
+        let someData = "text".data(using: .utf8)!
+        let asset = KBDataAsset(identifier: "testSecondayNonOptionalDiskWrite".hashValue, data: someData)
+
+        let expectWrite = expectation(description: "testSecondayNonOptionalDiskWrite")
+        storageManager
+            .store(asset, writeOption: [.disk, .optional])
+            .subscribe(onCompleted: {
+                expectWrite.fulfill()
+            }) { (error) in
+                XCTFail("Could not write to disk")
+            }
+            .disposed(by: disposeBag)
+
+        let expectSecondWrite = expectation(description: "testSecondayNonOptionalDiskSecondWrite")
+        storageManager
+            .store(asset, writeOption: [.disk])
+            .subscribe(onCompleted: {
+                expectSecondWrite.fulfill()
+            }) { (error) in
+                XCTFail("Should have written to disk")
+            }
+            .disposed(by: disposeBag)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testSecondaryWriteAfterOptional() {
+        // Writing to memory, and then writing to memory AND disk optionally
+        // Should return successful
+        let someData = "text".data(using: .utf8)!
+        let asset = KBDataAsset(identifier: "testSecondaryWriteAfterOptional".hashValue, data: someData)
+
+        let expectWrite = expectation(description: "testSecondaryWriteAfterOptional")
+        storageManager
+            .store(asset, writeOption: [.memory])
+            .subscribe(onCompleted: {
+                expectWrite.fulfill()
+            }) { (error) in
+                XCTFail("Could not write to disk")
+            }
+            .disposed(by: disposeBag)
+
+        let expectSkip = expectation(description: "testSecondaryWriteAfterOptionalSecond")
+        storageManager
+            .store(asset, writeOption: [.memory, .disk, .optional])
+            .subscribe(onCompleted: {
+                expectSkip.fulfill()
+            }) { (error) in
+                XCTFail("Should have written to disk")
+            }
+            .disposed(by: disposeBag)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
 }

--- a/Example/Tests/KBStorageManagerTests.swift
+++ b/Example/Tests/KBStorageManagerTests.swift
@@ -493,7 +493,7 @@ class KBStorageManagerTests: XCTestCase {
     }
 
     func testMemoryOptionalWriteAfterDiskWrite() {
-        // Writing to memory, and then writing to memory AND disk optionally
+        // Writing to disk, and then writing to disk AND memory optionally
         // Should return successful
         let someData = "text".data(using: .utf8)!
         let asset = KBDataAsset(identifier: "testMemoryOptionalWriteAfterDiskWrite".hashValue, data: someData)

--- a/KikBank/Classes/KBAsset.swift
+++ b/KikBank/Classes/KBAsset.swift
@@ -42,6 +42,14 @@ open class KBAsset: NSObject, KBAssetType {
         }
         return true
     }
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let otherAsset = object as? KBAssetType else {
+            return false
+        }
+
+        return identifier == otherAsset.identifier && expiryDate == otherAsset.expiryDate
+    }
 }
 
 extension KBAsset: NSCoding {

--- a/KikBank/Classes/KBAssetType.swift
+++ b/KikBank/Classes/KBAssetType.swift
@@ -14,4 +14,6 @@ public protocol KBAssetType: class, NSCoding {
     var expiryDate: Date? { get set }
     // Convenience accessor to calculate validity
     var isValid: Bool { get }
+
+    func isEqual(_ object: Any?) -> Bool
 }

--- a/KikBank/Classes/KBDataAsset.swift
+++ b/KikBank/Classes/KBDataAsset.swift
@@ -40,4 +40,12 @@ open class KBDataAsset: KBAsset, KBDataAssetType {
 
         aCoder.encode(data, forKey: Constants.dataKey)
     }
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let dataAsset = object as? KBDataAsset else {
+            return false
+        }
+
+        return super.isEqual(object) && data == dataAsset.data
+    }
 }

--- a/KikBank/Classes/KBParameters.swift
+++ b/KikBank/Classes/KBParameters.swift
@@ -19,10 +19,12 @@ import Foundation
 public struct KBReadOption: OptionSet {
     public let rawValue: Int
 
+    // Read Options
     public static let disk =    KBReadOption(rawValue: 1 << 0)
     public static let memory =  KBReadOption(rawValue: 1 << 1)
     public static let network = KBReadOption(rawValue: 1 << 2)
 
+    // Convenience Options
     public static let cache: KBReadOption = [.disk, .memory]
     public static let any: KBReadOption = [.disk, .memory, .network]
     public static let none: KBReadOption = []
@@ -37,15 +39,24 @@ public struct KBReadOption: OptionSet {
 
  - memory: Write item to memory, lost on storage dealloc
  - disk: Write item to disk, saved between sessions
- - all: Write item to memory and to disk storage
+ - optional: Check for existing equal item before performing a write operation
+        NOTE: .optional is a modifier write option
+              If only .optional is provided nothing will be saved
+ - cache: memory and disk
+ - none: No write required
  */
 public struct KBWriteOption: OptionSet {
     public let rawValue: Int
 
+    // Write Options
     public static let memory = KBWriteOption(rawValue: 1 << 0)
     public static let disk =   KBWriteOption(rawValue: 1 << 1)
 
-    public static let cache: KBWriteOption = [.memory, .disk]
+    // Modifier
+    public static let optional = KBWriteOption(rawValue: 1 << 2)
+
+    // Convenience Options
+    public static let cache: KBWriteOption = [.memory, .disk, .optional]
     public static let none: KBWriteOption = []
 
     public init(rawValue: Int) {
@@ -60,5 +71,5 @@ public class KBParameters: NSObject {
     public var readOption: KBReadOption = .any
 
     // The data write type
-    public var writeOption: KBWriteOption = .memory
+    public var writeOption: KBWriteOption = [.memory, .optional]
 }

--- a/KikBank/Classes/KBStorageManager.swift
+++ b/KikBank/Classes/KBStorageManager.swift
@@ -95,6 +95,7 @@ public class KBStorageManager {
 
     /// Delete operation queue
     private lazy var deleteSubject = PublishSubject<KBAssetType>()
+    
     private lazy var disposeBag = DisposeBag()
 
     public lazy var logger: KBLoggerType = KBLogger()
@@ -203,7 +204,7 @@ public class KBStorageManager {
             })
     }
 
-    /// Read an asset defined by a unique idenentifier from in-memory cache
+    /// Read an asset defined by a unique identifier from in-memory cache
     ///
     /// - Parameter key: The unique identifier of the data
     /// - Returns: An asset matching the provided key, if one exists
@@ -228,7 +229,7 @@ public class KBStorageManager {
             })
     }
 
-    /// Reads an asset defined by a unique idenentifier from disk if available
+    /// Reads an asset defined by a unique identifier from disk if available
     ///
     /// - Parameter key: The unique identifier of the data
     /// - Returns: An asset matching the provided key, if one exists
@@ -320,7 +321,7 @@ public class KBStorageManager {
             })
     }
 
-    /// Deletes the provided asset from memory storageg
+    /// Deletes the provided asset from memory storage
     ///
     /// - Parameter asset: The asset to be removed from memory
     private func deleteAssetFromMemory(_ asset: KBAssetType) -> Completable {
@@ -341,7 +342,7 @@ public class KBStorageManager {
             })
     }
 
-    /// Deletes the provided asset from disk storageg
+    /// Deletes the provided asset from disk storage
     ///
     /// - Parameter asset: The asset to be removed from disk
     private func deleteAssetFromDisk(_ asset: KBAssetType) -> Completable {

--- a/KikBank/Classes/KBStorageManager.swift
+++ b/KikBank/Classes/KBStorageManager.swift
@@ -9,14 +9,45 @@
 import Foundation
 import RxSwift
 
-enum KBStorageError: Error {
-    case deallocated
-    case badPath
-    case noWrite // Invalid write operation specified
-    case noRead // Invalid read operation specified
-    case notFound
-    case invalid
+enum KBStorageError: Error, Equatable {
+    case deallocated    // The storage manager has been deallocated
+    case badPath        // Could not create a path to the asset
+    case noWrite        // Invalid write operation specified
+    case noRead         // Invalid read operation specified
+    case notFound       // No asset found with that identifier
+    case invalid        // The asset failed validation and has been deleted
+    case optionalSkip   // An existing record is equal, no write required
     case generic(error: Error)
+
+    static func ==(lhs: KBStorageError, rhs: KBStorageError) -> Bool {
+        switch (lhs, rhs) {
+        case (.deallocated, .deallocated):
+            return true
+        case (.badPath, .badPath):
+            return true
+        case (.noWrite, .noWrite):
+            return true
+        case (.noRead, .noRead):
+            return true
+        case (.notFound, .notFound):
+            return true
+        case (.invalid, .invalid):
+            return true
+        case (.optionalSkip, .optionalSkip):
+            return true
+        case (.generic, .generic):
+            return true
+        case (.deallocated, _),
+             (.badPath, _),
+             (.noWrite, _),
+             (.noRead, _),
+             (.notFound, _),
+             (.invalid, _),
+             (.optionalSkip, _),
+             (.generic, _):
+            return false
+        }
+    }
 }
 
 public protocol KBStorageManagerType {
@@ -136,7 +167,7 @@ public class KBStorageManager {
             readOperation = readAssetFromMemory(with: identifier)
         } else if readOption == .disk {
             // Only read from disk
-            readOperation = readAssetFomDisk(with: identifier)
+            readOperation = readAssetFromDisk(with: identifier)
         } else if readOption.contains(.memory) && readOption.contains(.disk) {
             // Read memory and then disk if needed
             readOperation = readAssetFromMemory(with: identifier)
@@ -146,7 +177,7 @@ public class KBStorageManager {
                     }
 
                     // Could not read from memory, check disk
-                    return this.readAssetFomDisk(with: identifier)
+                    return this.readAssetFromDisk(with: identifier)
                 })
         }
 
@@ -201,7 +232,7 @@ public class KBStorageManager {
     ///
     /// - Parameter key: The unique identifier of the data
     /// - Returns: An asset matching the provided key, if one exists
-    private func readAssetFomDisk(with identifier: AnyHashable) -> Single<KBAssetType> {
+    private func readAssetFromDisk(with identifier: AnyHashable) -> Single<KBAssetType> {
         return Single
             .create(subscribe: { [weak self] (single) -> Disposable in
                 guard let this = self else {
@@ -351,12 +382,87 @@ extension KBStorageManager: KBStorageManagerType {
     public func store(_ asset: KBAssetType, writeOption: KBWriteOption) -> Completable {
         var completable = Completable.empty()
 
+        let isOptional = writeOption.contains(.optional)
+
         if writeOption.contains(.disk) {
-            completable = completable.andThen(writeToDisk(asset))
+            if isOptional {
+                completable = completable
+                    .andThen(readAssetFromDisk(with: asset.identifier))
+                    .asObservable()
+                    .catchError({ [weak self] (error) -> Observable<KBAssetType> in
+                        guard let this = self else {
+                            return .error(KBStorageError.deallocated)
+                        }
+
+                        if (error as? KBStorageError) == KBStorageError.notFound {
+                            // No record exists, we will need to write it
+                            return this
+                                .writeToDisk(asset)
+                                .asObservable()
+                                .flatMap({ (_) -> Observable<KBAssetType> in
+                                    return .just(asset)
+                                })
+                        }
+
+                        // Some other error was returned, let it propagate
+                        return .error(error)
+                    })
+                    .flatMap({ (existingAsset) -> Single<KBAssetType> in
+                        // If the existing item is equal to the write, we can skip
+                        if asset.isEqual(existingAsset) {
+                            // No need to write
+                            return .error(KBStorageError.optionalSkip)
+                        }
+
+                        return .just(asset)
+                    })
+                    .flatMap { _ in Observable<Never>.empty() }
+                    .asCompletable()
+            } else {
+                // Non optional write, so just append the next operation
+                completable = completable.andThen(writeToDisk(asset))
+            }
         }
 
         if writeOption.contains(.memory) {
-            completable = completable.andThen(writeToMemory(asset))
+            if isOptional {
+                // Check if a record exists before making a new request
+                completable = completable
+                    .andThen(readAssetFromMemory(with: asset.identifier))
+                    .asObservable()
+                    .catchError({ [weak self] (error) -> Observable<KBAssetType> in
+                        guard let this = self else {
+                            return .error(KBStorageError.deallocated)
+                        }
+
+                        if (error as? KBStorageError) == KBStorageError.notFound {
+                            // No record exists, we will need to write it
+                            return this
+                                .writeToMemory(asset)
+                                .asObservable()
+                                .flatMap({ (_) -> Observable<KBAssetType> in
+                                    return .just(asset)
+                                })
+                        }
+
+                        // Some other error was returned, let it propagate
+                        return .error(error)
+                    })
+                    .flatMap({ (existingAsset) -> Single<KBAssetType> in
+                        // If the existing item is equal to the write, we can skip
+                        if asset.isEqual(existingAsset) {
+                            // No need to write
+                            return .error(KBStorageError.optionalSkip)
+                        }
+
+                        return .just(asset)
+                    })
+                    .flatMap { _ in Observable<Never>.empty() }
+                    .asCompletable()
+            } else {
+                // Non optional write, so just append the next operation
+                completable = completable.andThen(writeToMemory(asset))
+            }
         }
 
         return completable

--- a/KikBank/Classes/KBStorageManager.swift
+++ b/KikBank/Classes/KBStorageManager.swift
@@ -392,22 +392,20 @@ extension KBStorageManager: KBStorageManagerType {
         var memoryError: Error?
 
         let diskWrite = writeToDisk(asset, options: writeOption)
-            .asObservable()
-            .catchError { (error) -> Observable<KBAssetType> in
+            .catchError { (error) -> Single<KBAssetType> in
                 diskError = error
                 return .just(asset)
         }
 
         let memoryWrite = writeToMemory(asset, options: writeOption)
-            .asObservable()
-            .catchError { (error) -> Observable<KBAssetType> in
+            .catchError { (error) -> Single<KBAssetType> in
                 memoryError = error
                 return .just(asset)
         }
 
-        return Observable
+        return Single
             .zip(diskWrite, memoryWrite) { return ($0, $1) }
-            .flatMap({ (_, _) -> Observable<KBAssetType> in
+            .flatMap({ (_, _) -> Single<KBAssetType> in
                 // Handle error cases
                 // If both disk and memory writes skipped
                 if (diskError as? KBStorageError) == KBStorageError.optionalSkip
@@ -446,8 +444,6 @@ extension KBStorageManager: KBStorageManagerType {
 
                 return .just(asset)
             })
-            .take(1)
-            .asSingle()
     }
 
     public func fetch(_ identifier: AnyHashable, readOption: KBReadOption) -> Single<KBAssetType> {

--- a/KikBank/Classes/KBStorageManager.swift
+++ b/KikBank/Classes/KBStorageManager.swift
@@ -208,9 +208,10 @@ public class KBStorageManager {
             })
     }
 
-    /// Check for an existing matching record, and if none exists write it to memory
+    /// Writes an asset to memory dependant on supplied options
     ///
-    /// - Parameter asset: The asset the be optionally writted to memory
+    /// - Parameter asset: The asset to be written to memory
+    /// - Parameter options: The write option parameters
     private func writeToMemory(_ asset: KBAssetType, options: KBWriteOption) -> Single<KBAssetType> {
         guard options.contains(.memory) else {
             return Single.error(KBStorageError.noWrite)
@@ -246,6 +247,9 @@ public class KBStorageManager {
             })
     }
 
+    /// Writes an asset to memory
+    ///
+    /// - Paremeter asset: The asset to be written to memory
     private func writeToMemory(_ asset: KBAssetType) -> Single<KBAssetType> {
         let assetData = NSKeyedArchiver.archivedData(withRootObject: asset)
         memoryCache[asset.identifier] = assetData
@@ -255,9 +259,10 @@ public class KBStorageManager {
         return .just(asset)
     }
 
-    /// Check for an existing matching record, and if none exists write it to disk
+    /// Writes an asset to disk dependant on supplied options
     ///
-    /// - Parameter asset: The asset the be optionally writted to disk
+    /// - Parameter asset: The asset to be written to disk
+    /// - Parameter options: The write option parameters
     private func writeToDisk(_ asset: KBAssetType, options: KBWriteOption) -> Single<KBAssetType> {
         guard options.contains(.disk) else {
             return Single.error(KBStorageError.noWrite)
@@ -293,9 +298,9 @@ public class KBStorageManager {
             })
     }
 
-    /// Write the provided asset to disk
+    /// Writes an asset to disk
     ///
-    /// - Parameter asset: The asset to be written to disk
+    /// - Paremeter asset: The asset to be written to memory
     private func writeToDisk(_ asset: KBAssetType) -> Single<KBAssetType> {
         guard let contentURL = contentURL else {
             return Single.error(KBStorageError.badPath)

--- a/KikBank/Classes/KikBank.swift
+++ b/KikBank/Classes/KikBank.swift
@@ -97,11 +97,10 @@ public class KikBank {
     }
 
     private func runSaveOperation(asset: KBAssetType, options: KBParameters) {
-        storageManager.store(asset, writeOption: options.writeOption).subscribe(onCompleted: {
-
-        }) { (error) in
-
-        }.disposed(by: disposeBag)
+        storageManager
+            .store(asset, writeOption: options.writeOption)
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 }
 


### PR DESCRIPTION
Adds a `KBWriteOption` parameter that allows optional saving, where if set the storage manager will check for an existing equal record and skip the write operation if one exists.